### PR TITLE
#36578: Improve subscription form layout on mobile screens

### DIFF
--- a/components/molecules/m-subscription-form.vue
+++ b/components/molecules/m-subscription-form.vue
@@ -30,7 +30,7 @@
           />
         </validation-provider>
 
-        <MSpinnerButton :show-spinner="isSubmitting">
+        <MSpinnerButton class="_submit-button" :show-spinner="isSubmitting">
           {{ buttonText }}
         </MSpinnerButton>
       </form>
@@ -170,15 +170,35 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+@import "theme/css/base/_breakpoints.scss";
+
 .m-subscription-form {
   --input-background: var(--_c-light-secondary);
 
   ._form {
     display: flex;
-    align-items: flex-start;
+    flex-direction: column;
 
     ._input {
-      flex: 1;
+      width: 100%;
+    }
+
+    ._submit-button {
+      --button-width: 100%;
+    }
+
+    @include for-tablet-up {
+      flex-direction: row;
+      align-items: flex-start;
+
+      ._input {
+        flex: 1;
+        width: auto;
+      }
+
+      ._submit-button {
+        --button-width: auto;
+      }
     }
   }
 
@@ -209,9 +229,16 @@ export default defineComponent({
   }
 
   .m-spinner-button {
-    margin-left: var(--spacer-base);
+    margin-top: var(--spacer-sm);
+    width: 100%;
     --button-font-size: var(--font-xs);
     --button-padding: calc(var(--spacer-base) * 0.56) var(--spacer-base);
+
+    @include for-tablet-up {
+      margin-top: 0;
+      margin-left: var(--spacer-base);
+      width: auto;
+    }
   }
 
   ._success-message {

--- a/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/design.md
+++ b/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The storefront reuses `m-subscription-form` as the shared implementation for newsletter and mailing-list subscription surfaces, including Storyblok-backed content blocks. Today the form layout is a single horizontal flex row with spacing tuned for larger viewports, which creates a cramped experience on narrow mobile screens.
+
+This change is constrained to presentation only. The existing submit action contract, validation rules, analytics/tracking hooks, persisted email behavior, and success-state flow must remain unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make reusable subscription forms render in a vertical mobile layout with the email input above the CTA.
+- Keep the change centralized in the shared component so all current consumers inherit the improvement consistently.
+- Preserve the current desktop and tablet behavior unless a layout adjustment is strictly required to support the mobile fix.
+- Prevent button text and control spacing from becoming cramped on common mobile widths.
+
+**Non-Goals:**
+- Changing subscription APIs, Vuex actions, validation messages, or success-state copy.
+- Introducing a new subscription form variant or a separate mobile-only component.
+- Redesigning nearby page sections outside the subscription form itself.
+
+## Decisions
+
+### Decision: Implement the responsive change in the shared `m-subscription-form` styles
+This component is the common rendering surface for newsletter and mailing-list forms, so a single scoped style change provides the broadest coverage with the smallest maintenance cost.
+
+Alternative considered: applying page-level or wrapper-level overrides.
+That was rejected because it would duplicate responsive rules across multiple surfaces and risks inconsistent behavior between direct theme usage and Storyblok usage.
+
+### Decision: Keep the existing markup and interaction flow, and only adjust responsive layout rules
+The current DOM order already places the email input before the CTA, which matches the intended mobile stack. Using responsive flex-direction, spacing, and width adjustments avoids touching validation, submit handling, or tracking-related behavior.
+
+Alternative considered: splitting the form into separate mobile and desktop templates.
+That was rejected because it would increase template complexity and create unnecessary risk for regressions in validation and submission handling.
+
+### Decision: Treat CTA sizing as part of the layout fix
+The button spacing and width need mobile-specific adjustment together with the vertical stack so the CTA remains readable and tappable rather than inheriting horizontal-row spacing that only works on wider screens.
+
+Alternative considered: stacking controls without changing CTA spacing or width.
+That was rejected because the existing left margin and compact sizing would leave the button visually misaligned in the stacked layout.
+
+## Risks / Trade-offs
+
+- Shared component impact across multiple surfaces -> Mitigation: keep the change CSS-only in the shared form component and verify newsletter, mailing-list, and Storyblok-backed usage.
+- Breakpoint choice could affect small tablets or large phones differently -> Mitigation: use the project’s existing mobile breakpoint convention and keep desktop/tablet layout unchanged above that threshold.
+- Scoped style changes may still be influenced by surrounding layout containers -> Mitigation: limit the change to the form row and CTA sizing so parent containers keep their current responsibilities.
+
+## Migration Plan
+
+No data migration or rollout sequencing is required. The change can ship as a standard storefront theme update and can be rolled back by reverting the shared component style change if a layout regression is found.
+
+## Open Questions
+
+None. The Redmine task defines the target behavior and explicitly excludes validation and submission changes.

--- a/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/proposal.md
+++ b/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Subscription forms currently render the email input and CTA button side by side, which becomes cramped on narrow mobile viewports and harder to use when the on-screen keyboard is open. This needs to be addressed now because the shared subscription form pattern is reused across storefront surfaces, so the layout problem can affect multiple customer entry points.
+
+## What Changes
+
+- Update the shared subscription form layout so mobile screens stack the email input above the CTA button.
+- Keep the existing horizontal layout for larger breakpoints unless the same readability issue exists there.
+- Ensure the CTA remains readable and tappable on narrow widths without changing validation, submission, tracking, or success-state behavior.
+- Apply the responsive layout change through the reusable subscription form component so newsletter and mailing-list variants inherit it consistently.
+
+## Capabilities
+
+### New Capabilities
+- `subscription-form-layout`: Defines responsive layout requirements for reusable subscription forms so mobile viewports display the email field and CTA in a vertical, readable, tappable arrangement.
+
+### Modified Capabilities
+None.
+
+## Impact
+
+- Affected code: shared subscription form component and any wrappers that reuse it, including newsletter, mailing-list, and Storyblok-backed subscription form surfaces.
+- Affected systems: storefront theme styling and responsive behavior only.
+- No API, analytics, validation, or submission contract changes are expected.

--- a/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/specs/subscription-form-layout/spec.md
+++ b/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/specs/subscription-form-layout/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Subscription forms stack controls on mobile viewports
+The system SHALL render reusable subscription forms in a vertical layout on mobile viewports so the email input appears above the related call-to-action button.
+
+#### Scenario: Shared subscription form renders stacked controls on mobile
+- **WHEN** a customer views any storefront surface that uses the shared subscription form on a mobile viewport
+- **THEN** the email input MUST be displayed above the call-to-action button
+- **THEN** the two controls MUST remain visually aligned as part of the same form
+
+### Requirement: Subscription form controls remain readable and tappable on narrow screens
+The system SHALL size and space the reusable subscription form controls on narrow mobile widths so button text does not become cramped and both controls remain comfortably tappable.
+
+#### Scenario: Mobile CTA remains usable on narrow widths
+- **WHEN** the shared subscription form is rendered on a narrow mobile viewport
+- **THEN** the call-to-action button text MUST remain readable without overflow caused by the responsive layout
+- **THEN** the input and button spacing MUST support comfortable touch interaction
+
+### Requirement: Responsive layout changes do not alter existing form behavior
+The system SHALL preserve the existing validation, submission, tracking, and success-state behavior of reusable subscription forms while applying the responsive mobile layout.
+
+#### Scenario: Existing subscription behavior is preserved
+- **WHEN** a customer interacts with a reusable subscription form after the responsive layout change
+- **THEN** validation rules, submission handling, and success messaging MUST behave the same as before the layout update
+- **THEN** larger viewports MUST continue using the existing non-mobile layout

--- a/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/tasks.md
+++ b/openspec/changes/archive/2026-05-02-36578-improve-mobile-subscription-form-layout/tasks.md
@@ -1,0 +1,14 @@
+## 1. Shared Form Layout
+
+- [x] 1.1 Update `src/themes/petsies-capybara/components/molecules/m-subscription-form.vue` to apply a mobile-specific stacked layout for the form row while preserving the existing larger-breakpoint layout.
+- [x] 1.2 Adjust shared CTA spacing and sizing in `m-subscription-form.vue` so the button remains aligned, readable, and tappable in the stacked mobile layout.
+
+## 2. Consumer Coverage
+
+- [x] 2.1 Verify newsletter, mailing-list, and Storyblok-backed subscription form consumers inherit the shared responsive layout without wrapper-specific overrides.
+- [x] 2.2 Confirm no additional template or store changes are required because the layout change stays within the shared presentational component.
+
+## 3. Regression Validation
+
+- [x] 3.1 Validate that subscription form validation, submission, persisted email behavior, and success-state rendering remain unchanged after the style update.
+- [x] 3.2 Check common mobile and non-mobile viewport widths to confirm stacked mobile behavior and unchanged larger-breakpoint layout.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/subscription-form-layout/spec.md
+++ b/openspec/specs/subscription-form-layout/spec.md
@@ -1,0 +1,23 @@
+### Requirement: Subscription forms stack controls on mobile viewports
+The system SHALL render reusable subscription forms in a vertical layout on mobile viewports so the email input appears above the related call-to-action button.
+
+#### Scenario: Shared subscription form renders stacked controls on mobile
+- **WHEN** a customer views any storefront surface that uses the shared subscription form on a mobile viewport
+- **THEN** the email input MUST be displayed above the call-to-action button
+- **THEN** the two controls MUST remain visually aligned as part of the same form
+
+### Requirement: Subscription form controls remain readable and tappable on narrow screens
+The system SHALL size and space the reusable subscription form controls on narrow mobile widths so button text does not become cramped and both controls remain comfortably tappable.
+
+#### Scenario: Mobile CTA remains usable on narrow widths
+- **WHEN** the shared subscription form is rendered on a narrow mobile viewport
+- **THEN** the call-to-action button text MUST remain readable without overflow caused by the responsive layout
+- **THEN** the input and button spacing MUST support comfortable touch interaction
+
+### Requirement: Responsive layout changes do not alter existing form behavior
+The system SHALL preserve the existing validation, submission, tracking, and success-state behavior of reusable subscription forms while applying the responsive mobile layout.
+
+#### Scenario: Existing subscription behavior is preserved
+- **WHEN** a customer interacts with a reusable subscription form after the responsive layout change
+- **THEN** validation rules, submission handling, and success messaging MUST behave the same as before the layout update
+- **THEN** larger viewports MUST continue using the existing non-mobile layout


### PR DESCRIPTION
## Summary

Improves the responsive layout of the shared subscription form so mobile viewports display the email input stacked above the CTA button instead of side by side.

Fixes the cramped experience on narrow screens and when the on-screen keyboard is open.

## Changes

- `components/molecules/m-subscription-form.vue` — CSS-only change. Mobile-first layout: stacked by default, horizontal row restored via `@include for-tablet-up`. CTA gets full width + top spacing on mobile; original left margin and auto width on larger screens.

All newsletter, mailing-list, and Storyblok-backed subscription form surfaces inherit the fix through the shared component. No template, Vuex, validation, or submission behavior was changed.

## References

Refs #36578